### PR TITLE
Add boolean source option for `insecure` (to use `-k` in `curl`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Then, a user will need to invite the account to the appropriate room, and the ac
 * `room_id`: *Required.* The room to send notifications to -- this account must already be a member of this room.
 * `msgtype`: Used to post a custom message type e.g. if you want to attach a json blob. If set to anything other than m.notice, the resource will attach a "build" json object containing the build metadata info. Defaults to `m.notice`, can be overridden by the put resource.
 * `data_file`: *Optional.* (string) Default file to post to the data key of a custom message type. The contents of this file is generally assumed to be a JSON-encoded string. Can be overridden in the job parameters.
+* `insecure`: *Optional.* (boolean) If true, disables SSL certificate verification for curl requests (uses curl -k/--insecure). Default is false.
 
 
 Pull requests accepted for room_alias, user logins, auto-joins.

--- a/bin/out
+++ b/bin/out
@@ -23,6 +23,12 @@ token="$(jq -r '.source.token' < "${payload}")"
 room_id="$(jq -r '.source.room_id' < "${payload}")"
 msgtype="$(jq -r '.source.msgtype // "m.notice"' < "${payload}")"
 data_file="$(jq -r '.source.data_file // ""' < "${payload}")"
+insecure="$(jq -r '.source.insecure // "false"' < "${payload}")"
+
+ADDITIONAL_CURL_OPTIONS=""
+if [[ "$insecure" == "true" ]]; then
+  ADDITIONAL_CURL_OPTIONS="-k"
+fi
 
 ts="$(date +%s%N)"
 
@@ -107,9 +113,9 @@ EOF
   if [[ "$silent" == "true" ]]
   then
     echo "Using silent output"
-    curl -s -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d "${compact_body}" "${matrix_endpoint}"
+    curl $ADDITIONAL_CURL_OPTIONS -s -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d "${compact_body}" "${matrix_endpoint}"
   else
-    curl -v -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d "${compact_body}" "${matrix_endpoint}"
+    curl $ADDITIONAL_CURL_OPTIONS -v -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' -d "${compact_body}" "${matrix_endpoint}"
   fi
 fi
 


### PR DESCRIPTION
Thanks for making this resource it's very useful. Here's an additional option for those using self-signed certs locally.